### PR TITLE
Update jquery.datetimepicker.full.js

### DIFF
--- a/build/jquery.datetimepicker.full.js
+++ b/build/jquery.datetimepicker.full.js
@@ -152,7 +152,7 @@ var DateFormatter;
                             vMeriOffset = _compare(mer, vSettings.meridiem[0]) ? 0 :
                                 (_compare(mer, vSettings.meridiem[1]) ? 12 : -1);
                             if (iDatePart >= 1 && iDatePart <= 12 && vMeriOffset > -1) {
-                                out.hour = iDatePart + vMeriOffset - 1;
+                                out.hour = iDatePart + vMeriOffset;
                             } else if (iDatePart >= 0 && iDatePart <= 23) {
                                 out.hour = iDatePart;
                             }


### PR DESCRIPTION
Fix the bug when a user selects time in the 12 hour format and date picker shows time at one hour late.
